### PR TITLE
CBMC: Add memmove stub to accelerate coverage

### DIFF
--- a/test/cbmc/proofs/MQTT_ProcessLoop/Makefile
+++ b/test/cbmc/proofs/MQTT_ProcessLoop/Makefile
@@ -48,6 +48,7 @@ INCLUDES +=
 REMOVE_FUNCTION_BODY += MQTT_Ping
 REMOVE_FUNCTION_BODY += MQTT_DeserializeAck
 REMOVE_FUNCTION_BODY += MQTT_SerializeAck
+REMOVE_FUNCTION_BODY += memmove # Use stub
 
 UNWINDSET += __CPROVER_file_local_core_mqtt_c_discardStoredPacket.0:$(MAX_NETWORK_RECV_TRIES)
 UNWINDSET += __CPROVER_file_local_core_mqtt_c_recvExact.0:$(MAX_NETWORK_RECV_TRIES)
@@ -72,6 +73,7 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_cbmc_state.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/network_interface_stubs.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/get_time_stub.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/event_callback_stub.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/memmove.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt_serializer.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt_state.c

--- a/test/cbmc/proofs/MQTT_ProcessLoop/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTT_ProcessLoop/cbmc-viewer.json
@@ -1,6 +1,8 @@
 { "expected-missing-functions":
   [
-
+    "MQTT_Ping",
+    "MQTT_SerializeAck",
+    "MQTT_DeserializeAck"
   ],
   "proof-name": "MQTT_ProcessLoop",
   "proof-root": "test/cbmc/proofs"

--- a/test/cbmc/proofs/MQTT_ReceiveLoop/Makefile
+++ b/test/cbmc/proofs/MQTT_ReceiveLoop/Makefile
@@ -29,6 +29,7 @@ INCLUDES +=
 # These functions have their memory saftey proven in other harnesses.
 REMOVE_FUNCTION_BODY += MQTT_DeserializeAck
 REMOVE_FUNCTION_BODY += MQTT_SerializeAck
+REMOVE_FUNCTION_BODY += memmove # Use stub
 
 # The loops below are unwound once more than the exclusive timeout bound.
 UNWINDSET += __CPROVER_file_local_core_mqtt_c_discardStoredPacket.0:$(MAX_NETWORK_RECV_TRIES)
@@ -53,6 +54,7 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/mqtt_cbmc_state.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/network_interface_stubs.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/get_time_stub.c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/event_callback_stub.c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/stubs/memmove.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt_serializer.c
 PROJECT_SOURCES += $(SRCDIR)/source/core_mqtt_state.c

--- a/test/cbmc/proofs/MQTT_ReceiveLoop/cbmc-viewer.json
+++ b/test/cbmc/proofs/MQTT_ReceiveLoop/cbmc-viewer.json
@@ -1,6 +1,7 @@
 { "expected-missing-functions":
   [
-
+    "MQTT_DeserializeAck",
+    "MQTT_SerializeAck"
   ],
   "proof-name": "MQTT_ReceiveLoop",
   "proof-root": "test/cbmc/proofs"

--- a/test/cbmc/stubs/memmove.c
+++ b/test/cbmc/stubs/memmove.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+void * memmove ( void * destination, const void * source, size_t num ) {
+  __CPROVER_assert(destination, "memmove destination is nonnull");
+  __CPROVER_assert(source, "memmove source is nonnull");
+  __CPROVER_havoc_object(destination);
+  return destination;
+}


### PR DESCRIPTION
The commit adds a stub for memmove accelerate CBMC coverage
calculation.  Without this stub, coverage for `MQTT_ProcessLoop` and
`MQTT_ReceiveLoop` fails to converge (gets stuck generating the SAT
formula for the memmove in `receiveSingleIteration`).  This stub
checks that src and dst are nonnull pointers and havocs dst.